### PR TITLE
Fix litellm bad request error

### DIFF
--- a/interpreter/core/llm/llm.py
+++ b/interpreter/core/llm/llm.py
@@ -293,7 +293,13 @@ Continuing...
         if self.api_version:
             params["api_version"] = self.api_version
         if self.max_tokens:
-            params["max_tokens"] = self.max_tokens
+            # Use max_completion_tokens for OpenAI o1 models, max_tokens for others
+            model_lower = self.model.lower() if self.model else ""
+            if ("o1-preview" in model_lower or "o1-mini" in model_lower or 
+                model_lower.startswith("o1") or "/o1" in model_lower):
+                params["max_completion_tokens"] = self.max_tokens
+            else:
+                params["max_tokens"] = self.max_tokens
         if self.temperature:
             params["temperature"] = self.temperature
         if hasattr(self.interpreter, "conversation_id"):


### PR DESCRIPTION
### Describe the changes you have made:
Implemented a fix to address `BadRequestError` when using OpenAI `o1` series models. The `max_tokens` parameter is now conditionally mapped to `max_completion_tokens` for `o1-preview`, `o1-mini`, and other `o1` variants, while `max_tokens` is retained for other models. This ensures compatibility with newer OpenAI models.

### Reference any relevant issues (e.g. "Fixes #000"):
Fixes `litellm.exceptions.BadRequestError: OpenAIException - Unsupported parameter: 'max_tokens' is not supported with this model. Use 'max_completion_tokens' instead.`

### Pre-Submission Checklist (optional but appreciated):

- [ ] I have included relevant documentation updates (stored in /docs)
- [ ] I have read `docs/CONTRIBUTING.md`
- [ ] I have read `docs/ROADMAP.md`

### OS Tests (optional but appreciated):

- [ ] Tested on Windows
- [ ] Tested on MacOS
- [ ] Tested on Linux

---
<a href="https://cursor.com/background-agent?bcId=bc-1b33c6b1-c157-4e46-a36c-bb1dc7496687">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1b33c6b1-c157-4e46-a36c-bb1dc7496687">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

