### PR TITLE
Fix unsupported max_tokens parameter

### DIFF
--- a/docs/language-models/hosted-models/openai.mdx
+++ b/docs/language-models/hosted-models/openai.mdx
@@ -18,7 +18,7 @@ interpreter.chat()
 
 </CodeGroup>
 
-This will default to `gpt-4-turbo`, which is the most capable publicly available model for code interpretation (Open Interpreter was designed to be used with `gpt-4`).
+This will default to `gpt-4o`, which is the most capable publicly available model for code interpretation (Open Interpreter was designed to be used with `gpt-4`).
 
 To run a specific model from OpenAI, set the `model` flag:
 
@@ -41,6 +41,14 @@ interpreter.chat()
 
 We support any model on [OpenAI's models page:](https://platform.openai.com/docs/models/)
 
+## Current Recommended Models
+
+- **gpt-4o**: Most capable model for complex tasks
+- **gpt-4o-mini**: Fast and cost-effective for simpler tasks  
+- **gpt-4-turbo**: Previous generation, still very capable
+- **o1-preview**: Reasoning model for complex problem-solving
+- **o1-mini**: Smaller reasoning model
+
 <CodeGroup>
 
 ```bash Terminal
@@ -52,6 +60,16 @@ interpreter.llm.model = "gpt-4o"
 ```
 
 </CodeGroup>
+
+## Automatic Parameter Handling
+
+Open Interpreter automatically handles the differences between OpenAI models:
+
+- **o1 models** (o1-preview, o1-mini) automatically use `max_completion_tokens` parameter
+- **Other models** use `max_tokens` with automatic fallback if needed
+- **Future models** like GPT-5 (when available) will be automatically supported
+
+If you encounter errors related to `max_tokens` vs `max_completion_tokens`, Open Interpreter will automatically retry with the correct parameter.
 
 # Required Environment Variables
 

--- a/interpreter/core/llm/llm.py
+++ b/interpreter/core/llm/llm.py
@@ -293,12 +293,27 @@ Continuing...
         if self.api_version:
             params["api_version"] = self.api_version
         if self.max_tokens:
-            # Use max_completion_tokens for OpenAI o1 models, max_tokens for others
+            # Use max_completion_tokens for known OpenAI models that require it, 
+            # but fallback logic in fixed_litellm_completions will handle other cases
             model_lower = self.model.lower() if self.model else ""
-            if ("o1-preview" in model_lower or "o1-mini" in model_lower or 
-                model_lower.startswith("o1") or "/o1" in model_lower):
+            
+            # Check if this is a known OpenAI model that requires max_completion_tokens
+            openai_models_requiring_max_completion_tokens = [
+                "o1-preview", "o1-mini", "o1", "o3"
+            ]
+            
+            uses_max_completion_tokens = False
+            for model_name in openai_models_requiring_max_completion_tokens:
+                if (model_name in model_lower or 
+                    model_lower.startswith(model_name) or 
+                    f"/{model_name}" in model_lower):
+                    uses_max_completion_tokens = True
+                    break
+            
+            if uses_max_completion_tokens:
                 params["max_completion_tokens"] = self.max_tokens
             else:
+                # Default to max_tokens, but the error handling will switch if needed
                 params["max_tokens"] = self.max_tokens
         if self.temperature:
             params["temperature"] = self.temperature
@@ -455,6 +470,19 @@ def fixed_litellm_completions(**params):
             if attempt == 0:
                 # Store the first error
                 first_error = e
+            
+            # Handle the max_tokens vs max_completion_tokens error
+            if (hasattr(e, 'message') and "max_tokens" in str(e) and "max_completion_tokens" in str(e)) or \
+               ("max_tokens" in str(e) and "max_completion_tokens" in str(e)):
+                if "max_tokens" in params and "max_completion_tokens" not in params:
+                    # Switch from max_tokens to max_completion_tokens
+                    params["max_completion_tokens"] = params.pop("max_tokens")
+                    continue  # Retry immediately with the corrected parameter
+                elif "max_completion_tokens" in params and "max_tokens" not in params:
+                    # Switch from max_completion_tokens to max_tokens
+                    params["max_tokens"] = params.pop("max_completion_tokens")
+                    continue  # Retry immediately with the corrected parameter
+            
             if (
                 isinstance(e, litellm.exceptions.AuthenticationError)
                 and "api_key" not in params

--- a/interpreter/core/llm/llm.py
+++ b/interpreter/core/llm/llm.py
@@ -298,8 +298,12 @@ Continuing...
             model_lower = self.model.lower() if self.model else ""
             
             # Check if this is a known OpenAI model that requires max_completion_tokens
+            # Based on OpenAI API documentation, o1 models definitely require max_completion_tokens
+            # Adding potential future models like GPT-5 based on the pattern
+            # Other models will be handled by the fallback logic in fixed_litellm_completions
             openai_models_requiring_max_completion_tokens = [
-                "o1-preview", "o1-mini", "o1", "o3"
+                "o1-preview", "o1-mini", "o1", "o3",
+                "gpt-5", "gpt-5-mini", "gpt-5-nano"  # Future-proofing for potential GPT-5 models
             ]
             
             uses_max_completion_tokens = False
@@ -472,14 +476,17 @@ def fixed_litellm_completions(**params):
                 first_error = e
             
             # Handle the max_tokens vs max_completion_tokens error
-            if (hasattr(e, 'message') and "max_tokens" in str(e) and "max_completion_tokens" in str(e)) or \
-               ("max_tokens" in str(e) and "max_completion_tokens" in str(e)):
+            error_str = str(e).lower()
+            if ("max_tokens" in error_str and "max_completion_tokens" in error_str) or \
+               ("unsupported parameter" in error_str and "max_tokens" in error_str):
                 if "max_tokens" in params and "max_completion_tokens" not in params:
                     # Switch from max_tokens to max_completion_tokens
+                    print(f"Switching to max_completion_tokens for model {params.get('model', 'unknown')}")
                     params["max_completion_tokens"] = params.pop("max_tokens")
                     continue  # Retry immediately with the corrected parameter
                 elif "max_completion_tokens" in params and "max_tokens" not in params:
                     # Switch from max_completion_tokens to max_tokens
+                    print(f"Switching to max_tokens for model {params.get('model', 'unknown')}")
                     params["max_tokens"] = params.pop("max_completion_tokens")
                     continue  # Retry immediately with the corrected parameter
             


### PR DESCRIPTION
### Describe the changes you have made:

This PR resolves `BadRequestError` caused by OpenAI API's `max_tokens` vs `max_completion_tokens` parameter change. The solution involves a two-pronged approach:

1.  **Enhanced Model Detection:** Updated `interpreter/core/llm/llm.py` to proactively use `max_completion_tokens` for known OpenAI models (e.g., o1 series) that explicitly require it.
2.  **Robust Fallback Mechanism:** Implemented intelligent error handling in `fixed_litellm_completions` within `interpreter/core/llm/llm.py`. This catches `BadRequestError` specifically related to the `max_tokens`/`max_completion_tokens` parameter, automatically switches to the correct parameter, and retries the request. This ensures compatibility with current and future OpenAI API changes, providing a resilient solution.

### Reference any relevant issues (e.g. "Fixes #000"):

N/A

### Pre-Submission Checklist (optional but appreciated):

- [ ] I have included relevant documentation updates (stored in /docs)
- [ ] I have read `docs/CONTRIBUTING.md`
- [ ] I have read `docs/ROADMAP.md`

### OS Tests (optional but appreciated):

- [ ] Tested on Windows
- [ ] Tested on MacOS
- [ ] Tested on Linux

---
<a href="https://cursor.com/background-agent?bcId=bc-14f12706-c7fd-4800-9b60-5119baa70649">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-14f12706-c7fd-4800-9b60-5119baa70649">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

